### PR TITLE
refactor: use query param for socket authorization

### DIFF
--- a/internal/middleware/auth.go
+++ b/internal/middleware/auth.go
@@ -57,5 +57,22 @@ func (a *AuthMiddleware) Websocket(c *fiber.Ctx) error {
 	if !websocket.IsWebSocketUpgrade(c) {
 		return apperror.UpgradeRequiredError(errors.New("your request is not intended for a websocket upgrade"), "your request is not intended for a websocket upgrade")
 	}
+
+	token := c.Query("token")
+	claims, err := a.jwtUtils.DecodeJWT(token)
+	if err != nil {
+		return apperror.UnauthorizedError(err, "Invalid token")
+	}
+
+	username := claims.Username
+
+	user, err := a.userRepo.GetUserByUsername(username)
+	if err != nil {
+		return apperror.UnauthorizedError(err, "User not found")
+	}
+
+	c.Locals("username", username)
+	c.Locals("user", user)
+
 	return c.Next()
 }

--- a/internal/server/route.go
+++ b/internal/server/route.go
@@ -16,7 +16,7 @@ func (s *Server) initRoutes() {
 }
 
 func (s *Server) initSocket() {
-	s.app.Use("/ws", s.middleware.Auth, s.middleware.Websocket)
+	s.app.Use("/ws", s.middleware.Websocket)
 	s.app.Get("/ws", websocket.New(s.handler.socketMessageHandler.InitConnection))
 
 }


### PR DESCRIPTION
Frontend couldn't find a way to connect to websocket and send authorization header.
So, change to sending jwt token in query param.
Eg. ws://backend/ws?token=jwtToken